### PR TITLE
Video Library Long Title Ellipsis

### DIFF
--- a/ui/pagelets/css/_video.scss
+++ b/ui/pagelets/css/_video.scss
@@ -63,8 +63,13 @@
 
     .title {
       font-weight: bold;
-      display: block;
       height: 40px;
+      -webkit-line-clamp: 2;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      text-overflow: ellipsis;
+      white-space: normal;
+      overflow: hidden;
     }
 
     .reveal {


### PR DESCRIPTION
Titles longer than 3 lines have the third line cut off halfway
This commit replaces the cutoff with an ellipsis

I considered that it would break the illusion that the shortened cards are just the top of the true card with the rest hidden, but it turns out there is no such illusion; on shorter video titles, the author should be visible if the cards were truly shortened versions